### PR TITLE
Add github workflows

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,14 @@
+name: Apply project management flow
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+jobs:
+  project-management:
+    runs-on: ubuntu-latest
+    name: Apply project management flow
+    steps:
+      - uses: honeycombio/oss-management-actions/projects@v1
+        with:
+          ghprojects-token: ${{ secrets.GHPROJECTS_TOKEN }}

--- a/.github/workflows/apply-labels.yml
+++ b/.github/workflows/apply-labels.yml
@@ -1,0 +1,10 @@
+name: Apply project labels
+on: [issues, pull_request_target, label]
+jobs:
+  apply-labels:
+    runs-on: ubuntu-latest
+    name: Apply common project labels
+    steps:
+      - uses: honeycombio/oss-management-actions/labels@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/re-triage.yml
+++ b/.github/workflows/re-triage.yml
@@ -1,0 +1,12 @@
+name: Re-triage issues with new comments
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  re-triage:
+    runs-on: ubuntu-latest
+    name: Re-triage issues with new comments
+    steps:
+      - uses: honeycombio/oss-management-actions/re-triage@v1
+        with:
+          ghprojects-token: ${{ secrets.GHPROJECTS_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    name: 'Close stale issues and PRs'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@v4
+        with:
+          start-date: '2021-09-01T00:00:00Z'
+          stale-issue-message: 'Marking this issue as stale because it has been open 14 days with no activity. Please add a comment if this is still an ongoing issue; otherwise this issue will be automatically closed in 7 days.'
+          stale-pr-message: 'Marking this PR as stale because it has been open 30 days with no activity. Please add a comment if this PR is still relevant; otherwise this PR will be automatically closed in 7 days.'
+          close-issue-message: 'Closing this issue due to inactivity. Please see our [Honeycomb OSS Lifecyle and Practices](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md).'
+          close-pr-message: 'Closing this PR due to inactivity. Please see our [Honeycomb OSS Lifecyle and Practices](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md).'
+          days-before-issue-stale: 14
+          days-before-pr-stale: 30
+          days-before-issue-close: 7
+          days-before-pr-close: 7
+          any-of-labels: 'status: info needed,status: revision needed'


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Adds the default Github workflows to manage lables, adding issues to Telemetry Team's board, stablebot, etc.
