### PR TITLE
maint: update github actions workflows

### DIFF
--- a/.github/workflows/apply-labels.yml
+++ b/.github/workflows/apply-labels.yml
@@ -1,5 +1,5 @@
 name: Apply project labels
-on: [issues, pull_request_target, label]
+on: [issues, pull_request, label]
 jobs:
   apply-labels:
     name: Apply common project labels

--- a/.github/workflows/apply-labels.yml
+++ b/.github/workflows/apply-labels.yml
@@ -8,6 +8,6 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: honeycombio/oss-management-actions/labels@v1
+      - uses: honeycombio/oss-management/labels@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/apply-labels.yml
+++ b/.github/workflows/apply-labels.yml
@@ -2,8 +2,8 @@ name: Apply project labels
 on: [issues, pull_request_target, label]
 jobs:
   apply-labels:
-    runs-on: ubuntu-latest
     name: Apply common project labels
+    runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/apply-labels.yml
+++ b/.github/workflows/apply-labels.yml
@@ -4,6 +4,9 @@ jobs:
   apply-labels:
     runs-on: ubuntu-latest
     name: Apply common project labels
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: honeycombio/oss-management-actions/labels@v1
         with:

--- a/.github/workflows/apply-labels.yml
+++ b/.github/workflows/apply-labels.yml
@@ -1,5 +1,5 @@
 name: Apply project labels
-on: [issues, pull_request, label]
+on: [issues, pull_request_target, label]
 jobs:
   apply-labels:
     name: Apply common project labels

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -11,6 +11,9 @@ jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         id: lint_pr_title


### PR DESCRIPTION
## Which problem is this PR solving?

- With the switch to GitHub Enterprise we introduced stricter permissions at the Org level for GitHub Actions, which disallows the setting for allowing read/write for all scopes. This means we need to manually provide access to individual workflows, at least for private repos. This resulted in some failed action workflows ("Validate PR Title" failed with Error: Resource not accessible by integration)
- Also, we've renamed the internal actions repo from `oss-management-actions` to `oss-management` and the workflow wasn't able to find the redirect at least on private repos, resulting in some failed action workflows ("Apply project labels" failed with Error: Unable to resolve action. Repository not found: honeycombio/oss-management-actions).

## Short description of the changes

- Update the `apply-labels.yml` workflow to use `oss-management`
- Give "write" permissions to `apply-labels.yml` and `validate-pr-title.yml`

## How to verify that this has the expected result

Successful GHA workflow runs. Note the [below comment related to the apply-labels workflow](https://github.com/honeycombio/.github/pull/17#issuecomment-1760154665)... at any rate this should be in a better state than it was, so I'm not sure how much time to dedicate to looking further into that 🤔 