### PR TITLE
fix(validate-pr-title): use PRT not PR

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,7 +1,7 @@
 name: "Validate PR Title"
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited


### PR DESCRIPTION
## Which problem is this PR solving?

- Private repos cannot be monitored by the semantic convention enforcer

## Short description of the changes

See https://github.com/amannn/action-semantic-pull-request/issues/173#issuecomment-1094910622

however, this by itself isn't enough as per https://github.com/honeycombio/loadgen/pull/27 - permissions may also need to explicitly be granted.