### PR TITLE
maint: add releaseyml for generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - no-changelog
+  categories:
+    - title: 💥 Breaking Changes 💥
+      labels:
+        - "version: bump major"
+        - breaking-change
+    - title: 💡 Enhancements
+      labels:
+        - "type: enhancement"
+    - title: 🐛 Fixes
+      labels:
+        - "type: bug"
+    - title: 🛠 Maintenance
+      labels:
+        - "type: maintenance"
+        - "type: dependencies"
+        - "type: documentation"
+    - title: 🤷 Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## Which problem is this PR solving?

- the `release.yml` will automatically sort PRs into groupings based on type label, making for less work needed to organize release notes

## Short description of the changes

- add `release.yml`

## How to verify that this has the expected result

repos that have this file and auto-generate release notes for releases will see items grouped under the appropriate header as long as the appropriate label is applied