### PR TITLE
ci: remove pipeline-team catch-all from CODEOWNERS [OTEL-125]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,2 @@
 # Code owners file.
 # This file controls who is tagged for review for any given pull request.
-
-# For anything not explicitly taken by someone else:
-* @honeycombio/pipeline-team
-


### PR DESCRIPTION
Removes the `* @honeycombio/pipeline-team` catch-all from the org-level CODEOWNERS.

The `pipeline-team` GitHub team has been renamed to `oss-maintainers` (the OTel maintainers team). Having this as an org-wide default would route review requests from any repo without explicit CODEOWNERS to the wrong team.

No replacement default is added — repos with no CODEOWNERS will simply have no required reviewer via CODEOWNERS (branch protection rules still apply per-repo).