### PR TITLE
ci: pin validate-pr-title actions to SHAs and bump to Node 24

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         id: lint_pr_title
         name: "🤖 Check PR title follows conventional commit spec"
         env:
@@ -40,7 +40,7 @@ jobs:
       # condition you can continue the execution with the populated error message.
       - if: always() && (steps.lint_pr_title.outputs.error_message != null)
         name: "📝 Add PR comment about using conventional commit spec"
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: pr-title-lint-error
           message: |
@@ -61,7 +61,7 @@ jobs:
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
         name: "❌ Delete PR comment after title has been updated"
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: pr-title-lint-error
           delete: true


### PR DESCRIPTION
## Summary
- Pin actions version to SHAs
- Bump to the latest majors, which resolves the "Node.js 20 actions are deprecated" warning seen on all of our runs. v6 of `action-semantic-pull-request` and v3 of `sticky-pull-request-comment` are pure Node 20 → Node 24 runtime bumps with no API changes.

| Action | Before | After |
| --- | --- | --- |
| `amannn/action-semantic-pull-request` | `@v5` | `@48f25628…` (v6.1.1) |
| `marocchino/sticky-pull-request-comment` | `@v2` | `@0ea0beb6…` (v3.0.4) |

## Test plan
- [ ] This workflow self-validates: the PR title check will run against this PR
- [ ] Confirm the run log no longer shows the Node 20 deprecation warning
- [ ] Confirm the sticky comment behavior still works (e.g. temporarily set a non-conventional title to verify the comment posts, then fix it to verify deletion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)